### PR TITLE
Remove CDPATH from environment

### DIFF
--- a/tester/test_logic.py
+++ b/tester/test_logic.py
@@ -18,6 +18,7 @@ from .config import (
 
 def run_command(command, shell_path, working_dir=None, no_env=False):
     env = {} if no_env else None
+    env.pop("CDPATH", None)
     try:
         result = subprocess.run(
             [shell_path, "-c", command], cwd=working_dir, capture_output=True, env=env

--- a/tester/test_logic.py
+++ b/tester/test_logic.py
@@ -17,7 +17,7 @@ from .config import (
 
 
 def run_command(command, shell_path, working_dir=None, no_env=False):
-    env = {} if no_env else None
+    env = {} if no_env else os.environ
     env.pop("CDPATH", None)
     try:
         result = subprocess.run(


### PR DESCRIPTION
When CDPATH is set (especially to the current working directory), every time you change your directory without specifying a relative or absolute path (as in `cd a` or even `cd a/b`), the absolute path of the destination directory will be printed to stdout. This fails some tests, and this PR fixes it by applying the idempotent `env.pop('CDPATH', None)` to the env variable.